### PR TITLE
Add melee mob block breaking with config management

### DIFF
--- a/src/main/java/com/demo/MobsAndDefenses.java
+++ b/src/main/java/com/demo/MobsAndDefenses.java
@@ -1,26 +1,26 @@
 package com.demo;
 
-import org.bukkit.plugin.java.JavaPlugin;
+import com.demo.listeners.MobSpawnListener;
+import com.demo.managers.ConfigManager;
 import com.demo.managers.PluginManager;
-import com.demo.listeners.PlayerListener;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public class MobsAndDefenses extends JavaPlugin {
-    
+
     @Override
     public void onEnable() {
-        
         // Initialize managers
-        PluginManager.getInstance().initialize();
-        
+        PluginManager.getInstance().initialize(this);
+        ConfigManager configManager = PluginManager.getInstance().getConfigManager();
+
         // Register listeners
-        getServer().getPluginManager().registerEvents(new PlayerListener(), this);
-        
-        getLogger().info("MobsAndDefenses has been enabled!");
+        getServer().getPluginManager().registerEvents(new MobSpawnListener(configManager), this);
+
+        getLogger().info("MobBreakBlocks has been enabled!");
     }
 
     @Override
     public void onDisable() {
-        getLogger().info("MobsAndDefenses has been disabled!");
+        getLogger().info("MobBreakBlocks has been disabled!");
     }
-    
 }

--- a/src/main/java/com/demo/goals/BreakBlockGoal.java
+++ b/src/main/java/com/demo/goals/BreakBlockGoal.java
@@ -1,0 +1,146 @@
+package com.demo.goals;
+
+import com.demo.managers.ConfigManager;
+import net.minecraft.world.entity.EntityCreature;
+import net.minecraft.world.entity.ai.goal.PathfinderGoal;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftLivingEntity;
+import org.bukkit.entity.*;
+import org.bukkit.util.Vector;
+
+import java.util.*;
+
+public class BreakBlockGoal extends PathfinderGoal {
+    private final EntityCreature mob;
+    private final Set<Material> soft;
+    private final Set<Material> hard;
+    private final long ticksSoft;
+    private final long ticksHard;
+    private final boolean showParticles;
+    private final double distance;
+    private Block targetBlock;
+    private int progress;
+    private static final Map<Block, Integer> progressMap = new HashMap<>();
+
+    public BreakBlockGoal(EntityCreature mob, ConfigManager config) {
+        this.mob = mob;
+        this.soft = config.getSoftBlocks();
+        this.hard = config.getHardBlocks();
+        this.ticksSoft = (long) (config.getSoftTime() * 20);
+        this.ticksHard = (long) (config.getHardTime() * 20);
+        this.showParticles = config.isShowParticles();
+        this.distance = config.getDetectionDistance();
+    }
+
+    @Override
+    public boolean canUse() {
+        org.bukkit.entity.Entity bukkit = mob.getBukkitEntity();
+        if (!(bukkit instanceof LivingEntity living)) {
+            return false;
+        }
+        if (!isAllowedMob(living)) {
+            return false;
+        }
+        if (mob.getGoalTarget() == null) {
+            return false;
+        }
+        Location loc = bukkit.getLocation();
+        Vector dir = loc.getDirection().setY(0).normalize();
+        Block block = loc.add(dir.multiply(distance)).getBlock();
+        if (!block.getType().isSolid() || block.getType() == Material.AIR) {
+            return false;
+        }
+        if (!soft.contains(block.getType()) && !hard.contains(block.getType())) {
+            return false;
+        }
+        targetBlock = block;
+        return true;
+    }
+
+    @Override
+    public boolean canContinueToUse() {
+        return targetBlock != null &&
+                targetBlock.getType() != Material.AIR &&
+                mob.getGoalTarget() != null &&
+                targetBlock.getType().isSolid();
+    }
+
+    @Override
+    public void start() {
+        progress = progressMap.getOrDefault(targetBlock, 0);
+    }
+
+    @Override
+    public void tick() {
+        if (targetBlock == null || targetBlock.getType() == Material.AIR || mob.getGoalTarget() == null) {
+            cleanup();
+            return;
+        }
+        if (showParticles) {
+            mob.getBukkitEntity().getWorld().spawnParticle(
+                    Particle.BLOCK_CRACK,
+                    targetBlock.getLocation().add(0.5, 0.5, 0.5),
+                    3, 0.3, 0.3, 0.3,
+                    targetBlock.getBlockData()
+            );
+        }
+        boolean isSoft = soft.contains(targetBlock.getType());
+        long threshold = isSoft ? ticksSoft : ticksHard;
+        progress++;
+        progressMap.put(targetBlock, progress);
+        if (progress >= threshold) {
+            targetBlock.breakNaturally();
+            progressMap.remove(targetBlock);
+            targetBlock = null;
+            progress = 0;
+        }
+    }
+
+    @Override
+    public void stop() {
+        cleanup();
+    }
+
+    private void cleanup() {
+        if (targetBlock != null) {
+            progressMap.remove(targetBlock);
+        }
+        targetBlock = null;
+        progress = 0;
+    }
+
+    // Allowed mobs list
+    private static final Set<Class<? extends LivingEntity>> ALLOWED = new HashSet<>(Arrays.asList(
+            Zombie.class,
+            Husk.class,
+            Drowned.class,
+            ZombieVillager.class,
+            Enderman.class,
+            IronGolem.class,
+            Ravager.class,
+            Hoglin.class,
+            ZombifiedPiglin.class,
+            Warden.class,
+            Giant.class,
+            Piglin.class,
+            PiglinBrute.class
+    ));
+
+    public static boolean isAllowedMob(LivingEntity entity) {
+        for (Class<? extends LivingEntity> clazz : ALLOWED) {
+            if (clazz.isInstance(entity)) {
+                if (entity instanceof Drowned drowned && drowned.getEquipment().getItemInMainHand().getType() == Material.TRIDENT) {
+                    return false;
+                }
+                if (entity instanceof Piglin piglin && piglin.getEquipment().getItemInMainHand().getType() == Material.CROSSBOW) {
+                    return false;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/demo/listeners/MobSpawnListener.java
+++ b/src/main/java/com/demo/listeners/MobSpawnListener.java
@@ -1,0 +1,39 @@
+package com.demo.listeners;
+
+import com.demo.goals.BreakBlockGoal;
+import com.demo.managers.ConfigManager;
+import net.minecraft.world.entity.EntityCreature;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftLivingEntity;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Monster;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+
+public class MobSpawnListener implements Listener {
+    private final ConfigManager config;
+
+    public MobSpawnListener(ConfigManager config) {
+        this.config = config;
+    }
+
+    @EventHandler
+    public void onCreatureSpawn(CreatureSpawnEvent event) {
+        LivingEntity entity = event.getEntity();
+        if (!(entity instanceof Monster) || entity instanceof Creeper) {
+            return;
+        }
+        if (!BreakBlockGoal.isAllowedMob(entity)) {
+            return;
+        }
+        try {
+            EntityCreature nms = ((CraftLivingEntity) entity).getHandle();
+            nms.goalSelector.addGoal(3, new BreakBlockGoal(nms, config));
+            Bukkit.getLogger().info("Added break block goal to: " + entity.getType());
+        } catch (Exception e) {
+            Bukkit.getLogger().warning("Failed to add goal to " + entity.getType() + ": " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/demo/managers/ConfigManager.java
+++ b/src/main/java/com/demo/managers/ConfigManager.java
@@ -1,0 +1,63 @@
+package com.demo.managers;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ConfigManager {
+    private final JavaPlugin plugin;
+    private Set<Material> softBlocks;
+    private Set<Material> hardBlocks;
+    private double softTime;
+    private double hardTime;
+    private boolean showParticles;
+    private double detectionDistance;
+
+    public ConfigManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        plugin.saveDefaultConfig();
+        reload();
+    }
+
+    public void reload() {
+        plugin.reloadConfig();
+        FileConfiguration cfg = plugin.getConfig();
+        softBlocks = cfg.getStringList("bloques.suaves").stream()
+                .map(Material::valueOf)
+                .collect(Collectors.toSet());
+        hardBlocks = cfg.getStringList("bloques.duros").stream()
+                .map(Material::valueOf)
+                .collect(Collectors.toSet());
+        softTime = cfg.getDouble("tiempos.suave", 2.0);
+        hardTime = cfg.getDouble("tiempos.duro", 5.0);
+        showParticles = cfg.getBoolean("configuracion.mostrar_particulas", true);
+        detectionDistance = cfg.getDouble("configuracion.distancia_deteccion", 1.5);
+    }
+
+    public Set<Material> getSoftBlocks() {
+        return softBlocks;
+    }
+
+    public Set<Material> getHardBlocks() {
+        return hardBlocks;
+    }
+
+    public double getSoftTime() {
+        return softTime;
+    }
+
+    public double getHardTime() {
+        return hardTime;
+    }
+
+    public boolean isShowParticles() {
+        return showParticles;
+    }
+
+    public double getDetectionDistance() {
+        return detectionDistance;
+    }
+}

--- a/src/main/java/com/demo/managers/PluginManager.java
+++ b/src/main/java/com/demo/managers/PluginManager.java
@@ -1,16 +1,28 @@
 package com.demo.managers;
 
+import org.bukkit.plugin.java.JavaPlugin;
+
 public class PluginManager {
-    private static PluginManager instance;
-    
+    private static final PluginManager instance = new PluginManager();
+    private JavaPlugin plugin;
+    private ConfigManager configManager;
+
+    private PluginManager() {}
+
     public static PluginManager getInstance() {
-        if (instance == null) {
-            instance = new PluginManager();
-        }
         return instance;
     }
-    
-    public void initialize() {
-        // Initialize your managers here
+
+    public void initialize(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.configManager = new ConfigManager(plugin);
+    }
+
+    public JavaPlugin getPlugin() {
+        return plugin;
+    }
+
+    public ConfigManager getConfigManager() {
+        return configManager;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,80 @@
+# Configuración de bloques y tiempos para el plugin MobBreakBlocks
+
+# MOBS PERMITIDOS (hardcodeados en el plugin):
+# ✅ Zombie (básico)
+# ✅ Husk (zombie del desierto)
+# ✅ Drowned (solo sin tridente)
+# ✅ ZombieVillager (aldeano zombie)
+# ✅ Enderman (ya puede mover bloques naturalmente)
+# ✅ IronGolem (golem de hierro)
+# ✅ Ravager (bestia del raid)
+# ✅ Hoglin (bestia del nether)
+# ✅ ZombifiedPiglin (piglin zombificado)
+# ✅ Warden (super fuerte)
+# ✅ Giant (si está disponible)
+# ✅ Piglin (solo sin ballesta)
+# ✅ PiglinBrute (siempre melee)
+#
+# MOBS EXCLUIDOS (no tiene sentido conceptual):
+# ❌ Skeleton, Stray, WitherSkeleton (arqueros)
+# ❌ Creeper (explota, no necesita romper)
+# ❌ Ghast (vuela y dispara)
+# ❌ Blaze (vuela y dispara)
+# ❌ Pillager, Vindicator, Evoker (humanoides inteligentes)
+# ❌ Witch (lanza pociones)
+# ❌ Spider, CaveSpider (muy pequeños)
+# ❌ Endermite, Silverfish (muy pequeños)
+# ❌ Slime, MagmaCube (gelatinosos)
+# ❌ Phantom (vuela)
+# ❌ Shulker (dispara proyectiles)
+
+bloques:
+  suaves:
+    - DIRT
+    - GRASS_BLOCK
+    - SAND
+    - GRAVEL
+    - SNOW_BLOCK
+    - CLAY
+    - COARSE_DIRT
+    - PODZOL
+    - MYCELIUM
+    - SOUL_SAND
+    - SOUL_SOIL
+    - MUD
+    - MUDDY_MANGROVE_ROOTS
+    - ROOTED_DIRT
+    - MOSS_BLOCK
+
+  duros:
+    - STONE
+    - COBBLESTONE
+    - DEEPSLATE
+    - COBBLED_DEEPSLATE
+    - ANDESITE
+    - GRANITE
+    - DIORITE
+    - CALCITE
+    - TUFF
+    - DRIPSTONE_BLOCK
+    - SANDSTONE
+    - RED_SANDSTONE
+    - BRICKS
+    - STONE_BRICKS
+    - DEEPSLATE_BRICKS
+    - POLISHED_DEEPSLATE
+    - BLACKSTONE
+    - POLISHED_BLACKSTONE
+    - NETHERRACK
+    - BASALT
+    - SMOOTH_BASALT
+    - END_STONE
+
+tiempos:
+  suave: 2.0
+  duro: 5.0
+
+configuracion:
+  mostrar_particulas: true
+  reproducir_sonido: true
+  distancia_deteccion: 1.5

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 main: com.demo.MobsAndDefenses
-version: 1.0.0-SNAPSHOT
-name: MobsAndDefenses
+version: 1.21.6
+name: MobBreakBlocks
 author: Luboi
 api-version: 1.20


### PR DESCRIPTION
## Summary
- add ConfigManager and enhance PluginManager
- register MobSpawnListener and implement BreakBlockGoal logic
- configure plugin.yml and add default config.yml

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a31c841788330ab6dd721b039fe08