### PR TITLE
Add BuildPathGoal for mob building

### DIFF
--- a/src/main/java/com/demo/goals/BuildPathGoal.java
+++ b/src/main/java/com/demo/goals/BuildPathGoal.java
@@ -1,0 +1,159 @@
+package com.demo.goals;
+
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.goal.Goal;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Directional;
+import org.bukkit.util.Vector;
+
+import java.util.EnumSet;
+
+/**
+ * Goal that allows a mob to place blocks when pathfinding fails.
+ */
+public class BuildPathGoal extends Goal {
+    private final Mob mob;
+    private final Material buildMaterial;
+    private final int maxBuildHeight;
+    private final double buildRange;
+    private Block targetBlock;
+    private int buildCooldown;
+
+    public BuildPathGoal(Mob mob, Material buildMaterial, int maxBuildHeight, double buildRange) {
+        this.mob = mob;
+        this.buildMaterial = buildMaterial;
+        this.maxBuildHeight = maxBuildHeight;
+        this.buildRange = buildRange;
+        this.setFlags(EnumSet.of(Flag.MOVE));
+    }
+
+    @Override
+    public boolean canUse() {
+        return mob.getTarget() != null
+                && mob.getNavigation().createPath(mob.getTarget(), 0) == null
+                && isTargetUnreachable();
+    }
+
+    private boolean isTargetUnreachable() {
+        Location mobLoc = mob.getBukkitEntity().getLocation();
+        Location targetLoc = mob.getTarget().getBukkitEntity().getLocation();
+
+        double heightDiff = targetLoc.getY() - mobLoc.getY();
+        if (heightDiff > 1.5 && heightDiff < maxBuildHeight) {
+            return true;
+        }
+
+        Vector direction = targetLoc.toVector().subtract(mobLoc.toVector());
+        double distance = direction.length();
+        if (distance > buildRange) {
+            return false;
+        }
+
+        direction.normalize();
+        for (double d = 1; d < Math.min(distance, buildRange); d += 0.5) {
+            Location checkLoc = mobLoc.clone().add(direction.clone().multiply(d));
+            Block block = checkLoc.getBlock();
+            if (block.getType().isSolid() || block.isLiquid()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void start() {
+        buildCooldown = 0;
+        selectBuildLocation();
+    }
+
+    private void selectBuildLocation() {
+        Location mobLoc = mob.getBukkitEntity().getLocation();
+        Location targetLoc = mob.getTarget().getBukkitEntity().getLocation();
+        Vector direction = targetLoc.toVector().subtract(mobLoc.toVector()).normalize();
+
+        Block underMob = mobLoc.clone().subtract(0, 1, 0).getBlock();
+        if (underMob.getType().isAir()) {
+            targetBlock = underMob;
+            return;
+        }
+
+        Block frontBlock = mobLoc.clone().add(direction).getBlock();
+        if (frontBlock.getType().isAir()) {
+            targetBlock = frontBlock;
+            return;
+        }
+
+        for (BlockFace face : new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST}) {
+            Block relative = frontBlock.getRelative(face);
+            if (relative.getType().isSolid()) {
+                targetBlock = frontBlock;
+                return;
+            }
+        }
+
+        Block above = mobLoc.clone().add(0, 1, 0).getBlock();
+        if (above.getType().isAir()) {
+            targetBlock = above;
+            return;
+        }
+
+        targetBlock = null;
+    }
+
+    @Override
+    public void tick() {
+        if (buildCooldown > 0) {
+            buildCooldown--;
+            return;
+        }
+
+        if (targetBlock == null || !targetBlock.getType().isAir()) {
+            selectBuildLocation();
+            if (targetBlock == null) {
+                return;
+            }
+        }
+
+        buildBlock(targetBlock);
+        buildCooldown = 20;
+    }
+
+    private void buildBlock(Block block) {
+        if (buildMaterial == Material.LADDER) {
+            placeLadder(block);
+        } else {
+            block.setType(buildMaterial, false);
+        }
+        block.getWorld().spawnParticle(
+                org.bukkit.Particle.BLOCK_DUST,
+                block.getLocation().add(0.5, 0.5, 0.5),
+                10, 0.3, 0.3, 0.3,
+                buildMaterial.createBlockData()
+        );
+    }
+
+    private void placeLadder(Block block) {
+        for (BlockFace face : new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST}) {
+            Block adjacent = block.getRelative(face);
+            if (adjacent.getType().isSolid()) {
+                block.setType(Material.LADDER, false);
+                BlockData data = block.getBlockData();
+                if (data instanceof Directional dir) {
+                    dir.setFacing(face);
+                    block.setBlockData(data, false);
+                }
+                return;
+            }
+        }
+        block.setType(buildMaterial, false);
+    }
+
+    @Override
+    public boolean requiresUpdateEveryTick() {
+        return true;
+    }
+}

--- a/src/main/java/com/demo/listeners/MobSpawnListener.java
+++ b/src/main/java/com/demo/listeners/MobSpawnListener.java
@@ -1,6 +1,7 @@
 package com.demo.listeners;
 
 import com.demo.goals.BreakBlockGoal;
+import com.demo.goals.BuildPathGoal;
 import com.demo.managers.ConfigManager;
 
 import net.minecraft.world.entity.PathfinderMob;
@@ -37,7 +38,13 @@ public class MobSpawnListener implements Listener {
             PathfinderMob nms = (PathfinderMob) craftEntity.getHandle();
             
             nms.goalSelector.addGoal(3, new BreakBlockGoal(nms, config));
-            Bukkit.getLogger().info("Added break block goal to: " + entity.getType());
+            nms.goalSelector.addGoal(4, new BuildPathGoal(
+                    nms,
+                    config.getBuildMaterial(),
+                    config.getMaxBuildHeight(),
+                    config.getBuildRange()
+            ));
+            Bukkit.getLogger().info("Added break and build goals to: " + entity.getType());
         } catch (Exception e) {
             Bukkit.getLogger().warning("Failed to add goal to " + entity.getType() + ": " + e.getMessage());
         }

--- a/src/main/java/com/demo/managers/ConfigManager.java
+++ b/src/main/java/com/demo/managers/ConfigManager.java
@@ -15,6 +15,9 @@ public class ConfigManager {
     private double hardTime;
     private boolean showParticles;
     private double detectionDistance;
+    private Material buildMaterial;
+    private int maxBuildHeight;
+    private double buildRange;
 
     public ConfigManager(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -35,6 +38,9 @@ public class ConfigManager {
         hardTime = cfg.getDouble("tiempos.duro", 5.0);
         showParticles = cfg.getBoolean("configuracion.mostrar_particulas", true);
         detectionDistance = cfg.getDouble("configuracion.distancia_deteccion", 1.5);
+        buildMaterial = Material.valueOf(cfg.getString("construccion.material", "DIRT").toUpperCase());
+        maxBuildHeight = cfg.getInt("construccion.max_altura", 5);
+        buildRange = cfg.getDouble("construccion.rango", 5.0);
     }
 
     public Set<Material> getSoftBlocks() {
@@ -59,5 +65,17 @@ public class ConfigManager {
 
     public double getDetectionDistance() {
         return detectionDistance;
+    }
+
+    public Material getBuildMaterial() {
+        return buildMaterial;
+    }
+
+    public int getMaxBuildHeight() {
+        return maxBuildHeight;
+    }
+
+    public double getBuildRange() {
+        return buildRange;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -78,3 +78,8 @@ configuracion:
   mostrar_particulas: true
   reproducir_sonido: true
   distancia_deteccion: 1.5
+
+construccion:
+  material: DIRT
+  max_altura: 5
+  rango: 5.0


### PR DESCRIPTION
## Summary
- allow mobs to build when pathfinding fails
- add building options to configuration
- hook building goal in spawn listener

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b012f1ec08330b0e915a36ae6a978