### PR TITLE
Enable unlimited building for mobs

### DIFF
--- a/src/main/java/com/demo/goals/BuildPathGoal.java
+++ b/src/main/java/com/demo/goals/BuildPathGoal.java
@@ -43,7 +43,8 @@ public class BuildPathGoal extends Goal {
         Location targetLoc = mob.getTarget().getBukkitEntity().getLocation();
 
         double heightDiff = targetLoc.getY() - mobLoc.getY();
-        if (heightDiff > 1.5 && heightDiff < maxBuildHeight) {
+        // Allow unlimited vertical building when maxBuildHeight is zero or negative
+        if (heightDiff > 1.5 && (maxBuildHeight <= 0 || heightDiff < maxBuildHeight)) {
             return true;
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -81,5 +81,6 @@ configuracion:
 
 construccion:
   material: DIRT
+  # Set max_altura to 0 or a negative value to allow unlimited building height
   max_altura: 5
   rango: 5.0


### PR DESCRIPTION
## Summary
- allow `BuildPathGoal` to use unlimited height when `max_altura` is 0 or negative
- document unlimited height option in `config.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b06b744e08330b002eecb99d428db