### PR TITLE
Add difficulty configuration loader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
                 <includes>
                     <include>plugin.yml</include>
                     <include>config.yml</include>
+                    <include>difficulty.yml</include>
                 </includes>
             </resource>
         </resources>

--- a/src/main/java/com/demo/MobsAndDefenses.java
+++ b/src/main/java/com/demo/MobsAndDefenses.java
@@ -4,6 +4,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import com.demo.listeners.MobSpawnListener;
 import com.demo.managers.ConfigManager;
+import com.demo.managers.DifficultyManager;
 import com.demo.managers.PluginManager;
 
 public class MobsAndDefenses extends JavaPlugin {
@@ -13,6 +14,7 @@ public class MobsAndDefenses extends JavaPlugin {
         // Initialize managers
         PluginManager.getInstance().initialize(this);
         ConfigManager configManager = PluginManager.getInstance().getConfigManager();
+        DifficultyManager difficultyManager = PluginManager.getInstance().getDifficultyManager();
 
         // Register listeners
         getServer().getPluginManager().registerEvents(new MobSpawnListener(configManager), this);

--- a/src/main/java/com/demo/managers/DifficultyManager.java
+++ b/src/main/java/com/demo/managers/DifficultyManager.java
@@ -1,0 +1,31 @@
+package com.demo.managers;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+
+public class DifficultyManager {
+    private final JavaPlugin plugin;
+    private FileConfiguration config;
+    private File file;
+
+    public DifficultyManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        // Ensure default file is copied if not present
+        plugin.saveResource("difficulty.yml", false);
+        reload();
+    }
+
+    public void reload() {
+        if (file == null) {
+            file = new File(plugin.getDataFolder(), "difficulty.yml");
+        }
+        config = YamlConfiguration.loadConfiguration(file);
+    }
+
+    public FileConfiguration getConfig() {
+        return config;
+    }
+}

--- a/src/main/java/com/demo/managers/PluginManager.java
+++ b/src/main/java/com/demo/managers/PluginManager.java
@@ -6,6 +6,7 @@ public class PluginManager {
     private static final PluginManager instance = new PluginManager();
     private JavaPlugin plugin;
     private ConfigManager configManager;
+    private DifficultyManager difficultyManager;
 
     private PluginManager() {}
 
@@ -16,6 +17,7 @@ public class PluginManager {
     public void initialize(JavaPlugin plugin) {
         this.plugin = plugin;
         this.configManager = new ConfigManager(plugin);
+        this.difficultyManager = new DifficultyManager(plugin);
     }
 
     public JavaPlugin getPlugin() {
@@ -24,5 +26,9 @@ public class PluginManager {
 
     public ConfigManager getConfigManager() {
         return configManager;
+    }
+
+    public DifficultyManager getDifficultyManager() {
+        return difficultyManager;
     }
 }

--- a/src/main/resources/difficulty.yml
+++ b/src/main/resources/difficulty.yml
@@ -1,0 +1,50 @@
+dificultades:
+  facil:
+    global:
+      multiplicador_vida: 1.0
+      inmunidad_sol: false
+      variedad_romper_bloques: 1
+      multiplicador_dano: 1.0
+      multiplicador_velocidad: 1.0
+      rango_deteccion: 16
+    mobs:
+      zombie:
+        romper_bloques: true
+        construir: true
+        multiplicador_vida: 1.0
+        multiplicador_velocidad: 1.0
+        rango_deteccion: 16
+        limite_recluta: 2
+  normal:
+    global:
+      multiplicador_vida: 1.05
+      inmunidad_sol: false
+      variedad_romper_bloques: 2
+      multiplicador_dano: 1.05
+      multiplicador_velocidad: 1.05
+      rango_deteccion: 20
+    mobs:
+      zombie:
+        romper_bloques: true
+        construir: true
+        multiplicador_vida: 1.05
+        multiplicador_velocidad: 1.2
+        rango_deteccion: 20
+        limite_recluta: 3
+  dificil:
+    global:
+      multiplicador_vida: 1.1
+      inmunidad_sol: true
+      variedad_romper_bloques: 3
+      multiplicador_dano: 1.1
+      multiplicador_velocidad: 1.1
+      rango_deteccion: 25
+    mobs:
+      zombie:
+        romper_bloques: true
+        construir: true
+        multiplicador_vida: 1.1
+        multiplicador_velocidad: 1.5
+        rango_deteccion: 25
+        limite_recluta: 5
+  # espacio para otros mobs con mas habilidades


### PR DESCRIPTION
## Summary
- add new `difficulty.yml` with adjustable global and mob difficulty settings
- load the new config via `DifficultyManager`
- integrate `DifficultyManager` into plugin lifecycle
- include new resource in build

## Testing
- `mvn -q -e -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c299b33d083308864628d464e835d