### PR TITLE
Add per-mob spawn handlers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
                     <include>plugin.yml</include>
                     <include>config.yml</include>
                     <include>difficulty.yml</include>
+                    <include>mobs/**</include>
                 </includes>
             </resource>
         </resources>

--- a/src/main/java/com/demo/MobsAndDefenses.java
+++ b/src/main/java/com/demo/MobsAndDefenses.java
@@ -2,7 +2,7 @@ package com.demo;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
-import com.demo.listeners.MobSpawnListener;
+import com.demo.mobs.Zombie.ZombieSpawnHandler;
 import com.demo.managers.ConfigManager;
 import com.demo.managers.DifficultyManager;
 import com.demo.managers.PluginManager;
@@ -16,9 +16,11 @@ public class MobsAndDefenses extends JavaPlugin {
         ConfigManager configManager = PluginManager.getInstance().getConfigManager();
         DifficultyManager difficultyManager = PluginManager.getInstance().getDifficultyManager();
 
-        // Register listeners
-        getServer().getPluginManager().registerEvents(new MobSpawnListener(configManager), this);
-        //comand registration
+        // Register mob spawn handlers based on configuration
+        if (difficultyManager.getMobConfig("zombie") != null) {
+            new ZombieSpawnHandler(this, configManager, difficultyManager).register();
+        }
+        // command registration
      
 
         getLogger().info("MobBreakBlocks has been enabled!");

--- a/src/main/java/com/demo/managers/ConfigManager.java
+++ b/src/main/java/com/demo/managers/ConfigManager.java
@@ -18,6 +18,7 @@ public class ConfigManager {
     private Material buildMaterial;
     private int maxBuildHeight;
     private double buildRange;
+    private String currentDifficulty;
 
     public ConfigManager(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -41,6 +42,7 @@ public class ConfigManager {
         buildMaterial = Material.valueOf(cfg.getString("construccion.material", "DIRT").toUpperCase());
         maxBuildHeight = cfg.getInt("construccion.max_altura", 5);
         buildRange = cfg.getDouble("construccion.rango", 5.0);
+        currentDifficulty = cfg.getString("dificultad_actual", "normal");
     }
 
     public Set<Material> getSoftBlocks() {
@@ -77,5 +79,9 @@ public class ConfigManager {
 
     public double getBuildRange() {
         return buildRange;
+    }
+
+    public String getCurrentDifficulty() {
+        return currentDifficulty;
     }
 }

--- a/src/main/java/com/demo/managers/DifficultyManager.java
+++ b/src/main/java/com/demo/managers/DifficultyManager.java
@@ -1,20 +1,26 @@
 package com.demo.managers;
 
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 public class DifficultyManager {
     private final JavaPlugin plugin;
     private FileConfiguration config;
     private File file;
+    private final Map<String, FileConfiguration> mobConfigs = new HashMap<>();
 
     public DifficultyManager(JavaPlugin plugin) {
         this.plugin = plugin;
-        // Ensure default file is copied if not present
+        // Ensure default files are copied if not present
         plugin.saveResource("difficulty.yml", false);
+        // Copy example mob config
+        plugin.saveResource("mobs/zombie.yml", false);
         reload();
     }
 
@@ -23,9 +29,26 @@ public class DifficultyManager {
             file = new File(plugin.getDataFolder(), "difficulty.yml");
         }
         config = YamlConfiguration.loadConfiguration(file);
+
+        mobConfigs.clear();
+        File mobsDir = new File(plugin.getDataFolder(), "mobs");
+        if (mobsDir.exists() && mobsDir.isDirectory()) {
+            for (File mobFile : mobsDir.listFiles((d, name) -> name.endsWith(".yml"))) {
+                String key = mobFile.getName().replaceFirst("\\.yml$", "").toLowerCase();
+                mobConfigs.put(key, YamlConfiguration.loadConfiguration(mobFile));
+            }
+        }
     }
 
     public FileConfiguration getConfig() {
         return config;
+    }
+
+    public ConfigurationSection getGlobalSection(String difficulty) {
+        return config.getConfigurationSection("dificultades." + difficulty + ".global");
+    }
+
+    public FileConfiguration getMobConfig(String mob) {
+        return mobConfigs.get(mob.toLowerCase());
     }
 }

--- a/src/main/java/com/demo/mobs/Zombie/ZombieConfigurator.java
+++ b/src/main/java/com/demo/mobs/Zombie/ZombieConfigurator.java
@@ -1,0 +1,43 @@
+package com.demo.mobs.Zombie;
+
+import com.demo.managers.DifficultyManager;
+import com.demo.mobs.common.IMobConfigurator;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import org.bukkit.configuration.ConfigurationSection;
+
+public class ZombieConfigurator implements IMobConfigurator {
+    @Override
+    public void configure(PathfinderMob mob, String difficulty, DifficultyManager difficultyManager) {
+        ConfigurationSection global = difficultyManager.getConfig()
+                .getConfigurationSection("dificultades." + difficulty + ".global");
+        ConfigurationSection mobSec = null;
+        if (difficultyManager.getMobConfig("zombie") != null) {
+            mobSec = difficultyManager.getMobConfig("zombie")
+                    .getConfigurationSection("dificultades." + difficulty);
+        }
+
+        double healthMult = 1.0;
+        double speedMult = 1.0;
+        double followRange = mob.getAttributeValue(Attributes.FOLLOW_RANGE);
+
+        if (global != null) {
+            healthMult *= global.getDouble("multiplicador_vida", 1.0);
+            speedMult *= global.getDouble("multiplicador_velocidad", 1.0);
+            followRange = global.getDouble("rango_deteccion", followRange);
+        }
+        if (mobSec != null) {
+            healthMult *= mobSec.getDouble("multiplicador_vida", 1.0);
+            speedMult *= mobSec.getDouble("multiplicador_velocidad", 1.0);
+            followRange = mobSec.getDouble("rango_deteccion", followRange);
+        }
+
+        double baseHealth = mob.getAttributeBaseValue(Attributes.MAX_HEALTH);
+        double baseSpeed = mob.getAttributeBaseValue(Attributes.MOVEMENT_SPEED);
+
+        mob.getAttribute(Attributes.MAX_HEALTH).setBaseValue(baseHealth * healthMult);
+        mob.setHealth((float) (baseHealth * healthMult));
+        mob.getAttribute(Attributes.MOVEMENT_SPEED).setBaseValue(baseSpeed * speedMult);
+        mob.getAttribute(Attributes.FOLLOW_RANGE).setBaseValue(followRange);
+    }
+}

--- a/src/main/java/com/demo/mobs/Zombie/ZombieSpawnHandler.java
+++ b/src/main/java/com/demo/mobs/Zombie/ZombieSpawnHandler.java
@@ -1,0 +1,53 @@
+package com.demo.mobs.Zombie;
+
+import com.demo.goals.BreakBlockGoal;
+import com.demo.goals.BuildPathGoal;
+import com.demo.mobs.common.BaseSpawnHandler;
+import com.demo.managers.ConfigManager;
+import com.demo.managers.DifficultyManager;
+import net.minecraft.world.entity.PathfinderMob;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftLivingEntity;
+import org.bukkit.entity.Zombie;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class ZombieSpawnHandler extends BaseSpawnHandler {
+    private final ZombieConfigurator configurator = new ZombieConfigurator();
+
+    public ZombieSpawnHandler(JavaPlugin plugin, ConfigManager configManager, DifficultyManager difficultyManager) {
+        super(plugin, configManager, difficultyManager);
+    }
+
+    @EventHandler
+    public void onSpawn(CreatureSpawnEvent event) {
+        if (!(event.getEntity() instanceof Zombie)) {
+            return;
+        }
+        String difficulty = configManager.getCurrentDifficulty();
+        CraftLivingEntity craft = (CraftLivingEntity) event.getEntity();
+        PathfinderMob nms = (PathfinderMob) craft.getHandle();
+        configurator.configure(nms, difficulty, difficultyManager);
+
+        ConfigurationSection mobSec = null;
+        if (difficultyManager.getMobConfig("zombie") != null) {
+            mobSec = difficultyManager.getMobConfig("zombie")
+                    .getConfigurationSection("dificultades." + difficulty);
+        }
+        if (mobSec == null) {
+            return;
+        }
+        if (mobSec.getBoolean("romper_bloques", false)) {
+            nms.goalSelector.addGoal(3, new BreakBlockGoal(nms, configManager));
+        }
+        if (mobSec.getBoolean("construir", false)) {
+            nms.goalSelector.addGoal(4, new BuildPathGoal(
+                    nms,
+                    configManager.getBuildMaterial(),
+                    configManager.getMaxBuildHeight(),
+                    configManager.getBuildRange()
+            ));
+        }
+    }
+}

--- a/src/main/java/com/demo/mobs/common/BaseSpawnHandler.java
+++ b/src/main/java/com/demo/mobs/common/BaseSpawnHandler.java
@@ -1,0 +1,22 @@
+package com.demo.mobs.common;
+
+import com.demo.managers.ConfigManager;
+import com.demo.managers.DifficultyManager;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public abstract class BaseSpawnHandler implements Listener {
+    protected final JavaPlugin plugin;
+    protected final ConfigManager configManager;
+    protected final DifficultyManager difficultyManager;
+
+    protected BaseSpawnHandler(JavaPlugin plugin, ConfigManager configManager, DifficultyManager difficultyManager) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.difficultyManager = difficultyManager;
+    }
+
+    public void register() {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+}

--- a/src/main/java/com/demo/mobs/common/IMobConfigurator.java
+++ b/src/main/java/com/demo/mobs/common/IMobConfigurator.java
@@ -1,0 +1,8 @@
+package com.demo.mobs.common;
+
+import net.minecraft.world.entity.PathfinderMob;
+import com.demo.managers.DifficultyManager;
+
+public interface IMobConfigurator {
+    void configure(PathfinderMob mob, String difficulty, DifficultyManager difficultyManager);
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -84,3 +84,4 @@ construccion:
   # Set max_altura to 0 or a negative value to allow unlimited building height
   max_altura: 20
   rango: 9.0
+dificultad_actual: normal

--- a/src/main/resources/difficulty.yml
+++ b/src/main/resources/difficulty.yml
@@ -7,14 +7,6 @@ dificultades:
       multiplicador_dano: 1.0
       multiplicador_velocidad: 1.0
       rango_deteccion: 16
-    mobs:
-      zombie:
-        romper_bloques: true
-        construir: true
-        multiplicador_vida: 1.0
-        multiplicador_velocidad: 1.0
-        rango_deteccion: 16
-        limite_recluta: 2
   normal:
     global:
       multiplicador_vida: 1.05
@@ -23,14 +15,6 @@ dificultades:
       multiplicador_dano: 1.05
       multiplicador_velocidad: 1.05
       rango_deteccion: 20
-    mobs:
-      zombie:
-        romper_bloques: true
-        construir: true
-        multiplicador_vida: 1.05
-        multiplicador_velocidad: 1.2
-        rango_deteccion: 20
-        limite_recluta: 3
   dificil:
     global:
       multiplicador_vida: 1.1
@@ -39,12 +23,3 @@ dificultades:
       multiplicador_dano: 1.1
       multiplicador_velocidad: 1.1
       rango_deteccion: 25
-    mobs:
-      zombie:
-        romper_bloques: true
-        construir: true
-        multiplicador_vida: 1.1
-        multiplicador_velocidad: 1.5
-        rango_deteccion: 25
-        limite_recluta: 5
-  # espacio para otros mobs con mas habilidades

--- a/src/main/resources/mobs/zombie.yml
+++ b/src/main/resources/mobs/zombie.yml
@@ -1,0 +1,22 @@
+dificultades:
+  facil:
+    romper_bloques: true
+    construir: true
+    multiplicador_vida: 1.0
+    multiplicador_velocidad: 1.0
+    rango_deteccion: 16
+    limite_recluta: 2
+  normal:
+    romper_bloques: true
+    construir: true
+    multiplicador_vida: 1.05
+    multiplicador_velocidad: 1.2
+    rango_deteccion: 20
+    limite_recluta: 3
+  dificil:
+    romper_bloques: true
+    construir: true
+    multiplicador_vida: 1.1
+    multiplicador_velocidad: 1.5
+    rango_deteccion: 25
+    limite_recluta: 5


### PR DESCRIPTION
## Summary
- add base spawn handler framework and mob configurator interface
- implement Zombie configurator and spawn handler
- register zombie spawn handler in main plugin
- expose current difficulty via ConfigManager
- include difficulty choice in config

## Testing
- `mvn -q package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5445f194833098818bb6ea29597c