### PR TITLE
Use server difficulty for mob config

### DIFF
--- a/src/main/java/com/demo/managers/DifficultyManager.java
+++ b/src/main/java/com/demo/managers/DifficultyManager.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bukkit.Difficulty;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -14,6 +15,23 @@ public class DifficultyManager {
     private FileConfiguration config;
     private File file;
     private final Map<String, FileConfiguration> mobConfigs = new HashMap<>();
+
+    /**
+     * Obtiene la dificultad actual del servidor y la mapea a la clave
+     * utilizada en los archivos YML de configuración.
+     *
+     * @return "facil", "normal" o "dificil" dependiendo de la dificultad
+     *         configurada en el servidor.
+     */
+    public String getDifficultyKey() {
+        Difficulty diff = plugin.getServer().getDifficulty();
+        return switch (diff) {
+            case EASY -> "facil";
+            case NORMAL -> "normal";
+            case HARD -> "dificil";
+            default -> "facil"; // PEACEFUL u otros valores
+        };
+    }
 
     public DifficultyManager(JavaPlugin plugin) {
         this.plugin = plugin;

--- a/src/main/java/com/demo/mobs/Zombie/ZombieSpawnHandler.java
+++ b/src/main/java/com/demo/mobs/Zombie/ZombieSpawnHandler.java
@@ -27,7 +27,7 @@ public class ZombieSpawnHandler extends BaseSpawnHandler {
         if (!(event.getEntity() instanceof Zombie)) {
             return;
         }
-        String difficulty = configManager.getCurrentDifficulty();
+        String difficulty = difficultyManager.getDifficultyKey();
         CraftLivingEntity craft = (CraftLivingEntity) event.getEntity();
         PathfinderMob nms = (PathfinderMob) craft.getHandle();
         configurator.configure(nms, difficulty, difficultyManager);


### PR DESCRIPTION
## Summary
- detect server difficulty inside `DifficultyManager`
- configure zombies based on detected difficulty instead of config value

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685c5f1726e483308e5d607a3ce05a57