### PR TITLE
Remove unused difficulty config

### DIFF
--- a/src/main/java/com/demo/managers/ConfigManager.java
+++ b/src/main/java/com/demo/managers/ConfigManager.java
@@ -18,7 +18,6 @@ public class ConfigManager {
     private Material buildMaterial;
     private int maxBuildHeight;
     private double buildRange;
-    private String currentDifficulty;
 
     public ConfigManager(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -42,7 +41,6 @@ public class ConfigManager {
         buildMaterial = Material.valueOf(cfg.getString("construccion.material", "DIRT").toUpperCase());
         maxBuildHeight = cfg.getInt("construccion.max_altura", 5);
         buildRange = cfg.getDouble("construccion.rango", 5.0);
-        currentDifficulty = cfg.getString("dificultad_actual", "normal");
     }
 
     public Set<Material> getSoftBlocks() {
@@ -79,9 +77,5 @@ public class ConfigManager {
 
     public double getBuildRange() {
         return buildRange;
-    }
-
-    public String getCurrentDifficulty() {
-        return currentDifficulty;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -84,4 +84,3 @@ construccion:
   # Set max_altura to 0 or a negative value to allow unlimited building height
   max_altura: 20
   rango: 9.0
-dificultad_actual: normal


### PR DESCRIPTION
## Summary
- drop `currentDifficulty` field and getter
- remove `dificultad_actual` from default config

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_685c64227028833095bca1b07fbe5f99