### PR TITLE
Implement sunlight immunity config

### DIFF
--- a/src/main/java/com/demo/MobsAndDefenses.java
+++ b/src/main/java/com/demo/MobsAndDefenses.java
@@ -6,6 +6,7 @@ import com.demo.managers.ConfigManager;
 import com.demo.managers.DifficultyManager;
 import com.demo.managers.PluginManager;
 import com.demo.mobs.Zombie.ZombieSpawnHandler;
+import com.demo.listeners.SunImmunityListener;
 
 public class MobsAndDefenses extends JavaPlugin {
 
@@ -22,6 +23,8 @@ public class MobsAndDefenses extends JavaPlugin {
         if (diffManager.getMobConfig("zombie") != null) {
             new ZombieSpawnHandler(this, configManager, diffManager).register();
         }
+        // Register sunlight immunity listener
+        getServer().getPluginManager().registerEvents(new SunImmunityListener(diffManager), this);
         // command registration
 
 

--- a/src/main/java/com/demo/listeners/SunImmunityListener.java
+++ b/src/main/java/com/demo/listeners/SunImmunityListener.java
@@ -1,0 +1,30 @@
+package com.demo.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityCombustEvent;
+
+import com.demo.managers.DifficultyManager;
+
+/**
+ * Cancels combustion caused by sunlight when the current difficulty
+ * configuration specifies sun immunity.
+ */
+public class SunImmunityListener implements Listener {
+    private final DifficultyManager difficultyManager;
+
+    public SunImmunityListener(DifficultyManager difficultyManager) {
+        this.difficultyManager = difficultyManager;
+    }
+
+    @EventHandler
+    public void onEntityCombust(EntityCombustEvent event) {
+        if (event.getCause() != EntityCombustEvent.Cause.SUN) {
+            return;
+        }
+        String difficulty = difficultyManager.getDifficultyKey();
+        if (difficultyManager.isSunImmune(difficulty)) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/com/demo/managers/DifficultyManager.java
+++ b/src/main/java/com/demo/managers/DifficultyManager.java
@@ -66,6 +66,18 @@ public class DifficultyManager {
         return config.getConfigurationSection("dificultades." + difficulty + ".global");
     }
 
+    /**
+     * Indicates if mobs should be immune to sunlight burns for the given
+     * difficulty.
+     *
+     * @param difficulty key returned by {@link #getDifficultyKey()}
+     * @return true if the configuration has "inmunidad_sol" enabled
+     */
+    public boolean isSunImmune(String difficulty) {
+        ConfigurationSection sec = getGlobalSection(difficulty);
+        return sec != null && sec.getBoolean("inmunidad_sol", false);
+    }
+
     public FileConfiguration getMobConfig(String mob) {
         return mobConfigs.get(mob.toLowerCase());
     }


### PR DESCRIPTION
## Summary
- add `isSunImmune` helper on `DifficultyManager`
- add `SunImmunityListener` to cancel sun burn
- register the listener in `MobsAndDefenses`

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_685c67bacce48330af81e5fd59b2d559