### PR TITLE
Add Skeleton configuration and behavior

### DIFF
--- a/src/main/java/com/demo/MobsAndDefenses.java
+++ b/src/main/java/com/demo/MobsAndDefenses.java
@@ -6,6 +6,7 @@ import com.demo.managers.ConfigManager;
 import com.demo.managers.DifficultyManager;
 import com.demo.managers.PluginManager;
 import com.demo.mobs.Zombie.ZombieSpawnHandler;
+import com.demo.mobs.Skeleton.SkeletonSpawnHandler;
 import com.demo.listeners.SunImmunityListener;
 
 public class MobsAndDefenses extends JavaPlugin {
@@ -22,6 +23,9 @@ public class MobsAndDefenses extends JavaPlugin {
         // Register mob spawn handlers based on configuration
         if (diffManager.getMobConfig("zombie") != null) {
             new ZombieSpawnHandler(this, configManager, diffManager).register();
+        }
+        if (diffManager.getMobConfig("skeleton") != null) {
+            new SkeletonSpawnHandler(this, configManager, diffManager).register();
         }
         // Register sunlight immunity listener
         getServer().getPluginManager().registerEvents(new SunImmunityListener(diffManager), this);

--- a/src/main/java/com/demo/managers/DifficultyManager.java
+++ b/src/main/java/com/demo/managers/DifficultyManager.java
@@ -37,8 +37,9 @@ public class DifficultyManager {
         this.plugin = plugin;
         // Ensure default files are copied if not present
         plugin.saveResource("difficulty.yml", false);
-        // Copy example mob config
+        // Copy example mob configs
         plugin.saveResource("mobs/zombie.yml", false);
+        plugin.saveResource("mobs/skeleton.yml", false);
         reload();
     }
 

--- a/src/main/java/com/demo/mobs/Skeleton/SkeletonConfigurator.java
+++ b/src/main/java/com/demo/mobs/Skeleton/SkeletonConfigurator.java
@@ -1,0 +1,42 @@
+package com.demo.mobs.Skeleton;
+
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Skeleton;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Configures skeleton attributes and equipment based on a configuration
+ * section.
+ */
+public class SkeletonConfigurator {
+
+    /**
+     * Applies configuration values to the given skeleton.
+     *
+     * @param skeleton the entity to configure
+     * @param sect     configuration section for the current difficulty
+     */
+    public void configure(Skeleton skeleton, ConfigurationSection sect) {
+        if (sect == null) {
+            return;
+        }
+        double range = sect.getDouble("follow-range", 40.0);
+        skeleton.getAttribute(Attribute.GENERIC_FOLLOW_RANGE)
+                .setBaseValue(range);
+        skeleton.setRemoveWhenFarAway(false);
+
+        ItemStack bow = new ItemStack(Material.BOW);
+        if (sect.getBoolean("enchanted-bow", true)) {
+            int power = sect.getInt("power-level", 2);
+            bow.addUnsafeEnchantment(Enchantment.ARROW_DAMAGE, power);
+            if (sect.getBoolean("allow-fire-arrows", false)) {
+                bow.addUnsafeEnchantment(Enchantment.ARROW_FIRE, 1);
+            }
+        }
+        skeleton.getEquipment().setItemInMainHand(bow);
+        skeleton.getEquipment().setHelmet(null);
+    }
+}

--- a/src/main/java/com/demo/mobs/Skeleton/SkeletonSpawnHandler.java
+++ b/src/main/java/com/demo/mobs/Skeleton/SkeletonSpawnHandler.java
@@ -1,0 +1,88 @@
+package com.demo.mobs.Skeleton;
+
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Projectile;
+import org.bukkit.entity.Skeleton;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import com.demo.managers.ConfigManager;
+import com.demo.managers.DifficultyManager;
+import com.demo.mobs.common.BaseSpawnHandler;
+
+/**
+ * Handles skeleton spawn and arrow events, applying explosive arrow logic.
+ */
+public class SkeletonSpawnHandler extends BaseSpawnHandler {
+    private static final String META_EXPLOSIVE = "explosive";
+
+    public SkeletonSpawnHandler(JavaPlugin plugin,
+                                ConfigManager configManager,
+                                DifficultyManager difficultyManager) {
+        super(plugin, configManager, difficultyManager);
+    }
+
+    private ConfigurationSection getSection() {
+        if (difficultyManager.getMobConfig("skeleton") == null) {
+            return null;
+        }
+        String difficulty = difficultyManager.getDifficultyKey();
+        return difficultyManager.getMobConfig("skeleton")
+                .getConfigurationSection("dificultades." + difficulty);
+    }
+
+    @EventHandler
+    public void onSpawn(CreatureSpawnEvent event) {
+        if (!(event.getEntity() instanceof Skeleton skeleton)) {
+            return;
+        }
+        ConfigurationSection sec = getSection();
+        if (sec == null) {
+            return;
+        }
+        new SkeletonConfigurator().configure(skeleton, sec);
+    }
+
+    @EventHandler
+    public void onShoot(EntityShootBowEvent event) {
+        if (!(event.getEntity() instanceof Skeleton)) {
+            return;
+        }
+        if (!(event.getProjectile() instanceof Arrow arrow)) {
+            return;
+        }
+        ConfigurationSection sec = getSection();
+        if (sec == null) {
+            return;
+        }
+        double chance = sec.getDouble("explosive-arrow-chance", 0.0);
+        if (sec.getBoolean("allow-explosive-arrows", false) && Math.random() < chance) {
+            arrow.setMetadata(META_EXPLOSIVE, new FixedMetadataValue(plugin, true));
+        }
+    }
+
+    @EventHandler
+    public void onProjectileHit(ProjectileHitEvent event) {
+        Projectile proj = event.getEntity();
+        if (!(proj instanceof Arrow)) {
+            return;
+        }
+        if (!proj.hasMetadata(META_EXPLOSIVE)) {
+            return;
+        }
+        ConfigurationSection sec = getSection();
+        if (sec == null) {
+            return;
+        }
+        Location loc = proj.getLocation();
+        float power = (float) sec.getDouble("explosion-power", 2.0);
+        loc.getWorld().createExplosion(loc, power, false, false);
+        proj.remove();
+    }
+}

--- a/src/main/resources/mobs/skeleton.yml
+++ b/src/main/resources/mobs/skeleton.yml
@@ -1,0 +1,25 @@
+dificultades:
+  facil:
+    follow-range: 25
+    enchanted-bow: true
+    power-level: 1
+    allow-fire-arrows: false
+    allow-explosive-arrows: false
+    explosive-arrow-chance: 0.0
+    explosion-power: 2.0
+  normal:
+    follow-range: 35
+    enchanted-bow: true
+    power-level: 2
+    allow-fire-arrows: true
+    allow-explosive-arrows: true
+    explosive-arrow-chance: 0.1
+    explosion-power: 2.0
+  dificil:
+    follow-range: 45
+    enchanted-bow: true
+    power-level: 3
+    allow-fire-arrows: true
+    allow-explosive-arrows: true
+    explosive-arrow-chance: 0.2
+    explosion-power: 3.0


### PR DESCRIPTION
## Summary
- add new `skeleton.yml` with ranged attack options
- create `SkeletonConfigurator` to read config and apply skeleton settings
- create `SkeletonSpawnHandler` to manage spawning and explosive arrows
- ensure default skeleton config is saved
- register new handler in the main plugin

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d79a0730c8330ae7c6f95945cd918