### PR TITLE
Fix turret key initialization order

### DIFF
--- a/src/main/java/com/demo/managers/PluginManager.java
+++ b/src/main/java/com/demo/managers/PluginManager.java
@@ -10,10 +10,13 @@ public class PluginManager {
 
     /** Register crafting and event handlers for turret defenses. */
     public void registerDefenses() {
-        com.demo.defenses.crafting.TurretCrafting crafting = new com.demo.defenses.crafting.TurretCrafting(plugin);
-        crafting.registerRecipes();
-
+        // Setup the turret manager before creating items that rely on its key
         com.demo.defenses.manager.TurretManager.setup(plugin);
+
+        // Register crafting recipes once the key is initialized
+        com.demo.defenses.crafting.TurretCrafting crafting =
+                new com.demo.defenses.crafting.TurretCrafting(plugin);
+        crafting.registerRecipes();
 
         var pm = plugin.getServer().getPluginManager();
         pm.registerEvents(new com.demo.defenses.spawn.TurretSpawnHandler(plugin), plugin);


### PR DESCRIPTION
## Summary
- set up the turret manager before registering turret recipes

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_685d9099f08c83309513e5806bccd506