### PR TITLE
Implement turret control system

### DIFF
--- a/src/main/java/com/demo/MobsAndDefenses.java
+++ b/src/main/java/com/demo/MobsAndDefenses.java
@@ -13,6 +13,7 @@ import com.demo.mobs.spider.SpiderTrapHandler;
 import com.demo.mobs.wither.WitherBlastHandler;
 import com.demo.mobs.ghast.GhastHomingHandler;
 import com.demo.listeners.SunImmunityListener;
+import com.demo.defenses.manager.TurretControlManager;
 
 public class MobsAndDefenses extends JavaPlugin {
 
@@ -58,6 +59,7 @@ public class MobsAndDefenses extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        TurretControlManager.cleanup();
         getLogger().info("MobsAndDefenses has been disabled!");
     }
 }

--- a/src/main/java/com/demo/defenses/listener/TurretInteractListener.java
+++ b/src/main/java/com/demo/defenses/listener/TurretInteractListener.java
@@ -6,10 +6,12 @@ import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
+import com.demo.defenses.manager.TurretControlManager;
 import com.demo.defenses.manager.TurretManager;
 import com.demo.defenses.model.Turret;
 
@@ -28,6 +30,31 @@ public class TurretInteractListener implements Listener {
         handleTurretInteraction(e.getPlayer(), e.getRightClicked(), e);
     }
     
+    /**
+     * Maneja los clicks en el aire para disparar cuando se controla una torreta
+     */
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent e) {
+        Player player = e.getPlayer();
+        
+        // Solo procesar clicks derechos
+        if (!e.getAction().name().contains("RIGHT_CLICK")) return;
+        
+        // Verificar si el jugador está controlando una torreta
+        if (TurretControlManager.isControlling(player)) {
+            e.setCancelled(true);
+            TurretControlManager.fireTurret(player);
+        }
+    }
+    
+    /**
+     * Limpia el control cuando un jugador se desconecta
+     */
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent e) {
+        TurretControlManager.stopControlling(e.getPlayer());
+    }
+    
     private void handleTurretInteraction(Player player, org.bukkit.entity.Entity entity, org.bukkit.event.Cancellable event) {
         if (!(entity instanceof ArmorStand stand)) return;
         
@@ -37,54 +64,86 @@ public class TurretInteractListener implements Listener {
         
         event.setCancelled(true);
         
+        // Si el jugador está controlando esta torreta y hace Shift+Click, salir del control
+        if (TurretControlManager.isControlling(player) && player.isSneaking()) {
+            Turret controlledTurret = TurretControlManager.getControlledTurret(player);
+            if (controlledTurret != null && controlledTurret.getStandId().equals(id)) {
+                TurretControlManager.stopControlling(player);
+                turret.toggleActive(); // Desactivar la torreta
+                stand.setGlowing(false);
+                return;
+            }
+        }
         
+        // Verificar si el jugador está en modo creativo y tiene un ítem que podría romper la torreta
+        if (player.isOp() && player.isSneaking() && player.getInventory().getItemInMainHand().getType().name().contains("AXE")) {
+            // Los ops pueden destruir torretas con un hacha mientras se agachan
+            player.sendMessage("§cTorreta destruida por administrador");
+            
+            // Si alguien está controlando esta torreta, detener el control
+            if (TurretControlManager.getControlledTurret(player) != null) {
+                TurretControlManager.stopControlling(player);
+            }
+            
+            TurretManager.destroyTurret(id);
+            return;
+        }
+        
+        // Si el jugador ya está controlando otra torreta, no puede activar esta
+        if (TurretControlManager.isControlling(player)) {
+            player.sendMessage("§cYa estás controlando otra torreta. Usa Shift+Click para salir del control primero.");
+            return;
+        }
         
         if (player.isSneaking()) {
+            // Activar/desactivar torreta
             turret.toggleActive();
-            player.sendMessage("§aModo torreta: §f" + (turret.isActive() ? "§2activado" : "§cdesactivado"));
             
-            // Efecto visual del estado
             if (turret.isActive()) {
-                stand.setGlowing(true);
+                // Intentar iniciar el control
+                if (TurretControlManager.startControlling(player, turret)) {
+                    player.sendMessage("§aModo torreta: §2activado §f- Ahora controlas la torreta");
+                    stand.setGlowing(true);
+                } else {
+                    // Si no se puede controlar, desactivar
+                    turret.toggleActive();
+                    player.sendMessage("§cNo se pudo activar la torreta (puede estar siendo controlada por otro jugador)");
+                }
             } else {
+                // Desactivar torreta
+                TurretControlManager.stopControlling(player);
+                player.sendMessage("§aModo torreta: §cdesactivado");
                 stand.setGlowing(false);
             }
             return;
         }
         
+        // Click normal sin Shift
         if (turret.isActive()) {
-            if (turret.isReady()) {
-                turret.fire(player, stand);
-                player.sendMessage("§e¡Pum! Torreta disparada");
-            } else {
-                player.sendMessage("§6Torreta recargando...");
-            }
+            player.sendMessage("§6Esta torreta ya está siendo controlada. Usa Shift+Click para activar/desactivar.");
         } else {
-            player.sendMessage("§cLa torreta está desactivada. Usa Shift+Click para activarla");
+            player.sendMessage("§cLa torreta está desactivada. Usa Shift+Click para activarla y controlarla.");
         }
     }
 
-
-
-    @EventHandler 
-    public void onTurretDestroy(EntityDeathEvent event) {
+    @EventHandler
+    public void onTurretDestroy(org.bukkit.event.entity.EntityDeathEvent event) {
         if (!(event.getEntity() instanceof ArmorStand stand)) return;
-        
+
         Turret turret = TurretManager.getTurret(stand.getUniqueId());
         if (turret == null) return;
-        
+
         // Limpiar la torreta del registro cuando muere
         TurretManager.unregister(stand.getUniqueId());
-        
-        // Opcional: Mensaje de destrucción
-        stand.getWorld().getPlayers().forEach(player -> {
-            if (player.getLocation().distance(stand.getLocation()) <= 50) {
-                player.sendMessage("§8Una torreta ha sido destruida en " + 
-                    stand.getLocation().getBlockX() + ", " + 
-                    stand.getLocation().getBlockY() + ", " + 
-                    stand.getLocation().getBlockZ());
+
+        // Mensaje de destrucción opcional
+        stand.getWorld().getPlayers().forEach(p -> {
+            if (p.getLocation().distance(stand.getLocation()) <= 50) {
+                p.sendMessage("§8Una torreta ha sido destruida en " +
+                        stand.getLocation().getBlockX() + ", " +
+                        stand.getLocation().getBlockY() + ", " +
+                        stand.getLocation().getBlockZ());
             }
         });
     }
 }
-

--- a/src/main/java/com/demo/defenses/manager/TurretControlManager.java
+++ b/src/main/java/com/demo/defenses/manager/TurretControlManager.java
@@ -1,0 +1,244 @@
+package com.demo.defenses.manager;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.EulerAngle;
+
+import com.demo.defenses.model.Turret;
+
+/**
+ * Maneja el control activo de torretas por jugadores.
+ */
+public class TurretControlManager {
+    
+    // Mapa de jugadores controlando torretas: Player UUID -> Turret UUID
+    private static final Map<UUID, UUID> ACTIVE_CONTROLLERS = new HashMap<>();
+    
+    // Mapa de torretas siendo controladas: Turret UUID -> Player UUID
+    private static final Map<UUID, UUID> CONTROLLED_TURRETS = new HashMap<>();
+    
+    // Task para actualizar las rotaciones
+    private static BukkitRunnable updateTask;
+    
+    // Límites de rotación
+    private static final double MAX_YAW_OFFSET = 90.0; // 90 grados a cada lado (180 total)
+    private static final double MAX_PITCH_UP = -90.0;  // 90 grados hacia arriba
+    private static final double MAX_PITCH_DOWN = 20.0;  // 20 grados hacia abajo
+    
+    /**
+     * Inicia el control de una torreta por un jugador
+     */
+    public static boolean startControlling(Player player, Turret turret) {
+        UUID playerId = player.getUniqueId();
+        UUID turretId = turret.getStandId();
+        
+        // Verificar si el jugador ya está controlando otra torreta
+        if (ACTIVE_CONTROLLERS.containsKey(playerId)) {
+            stopControlling(player);
+        }
+        
+        // Verificar si la torreta ya está siendo controlada
+        if (CONTROLLED_TURRETS.containsKey(turretId)) {
+            return false;
+        }
+        
+        // Registrar el control
+        ACTIVE_CONTROLLERS.put(playerId, turretId);
+        CONTROLLED_TURRETS.put(turretId, playerId);
+        
+        // Inmovilizar al jugador
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, Integer.MAX_VALUE, 255, false, false));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP_BOOST, Integer.MAX_VALUE, -10, false, false));
+        
+        // Mensaje al jugador
+        player.sendMessage("§aControlando torreta. Click derecho para disparar, Shift+Click para salir.");
+        
+        // Iniciar el task de actualización si no está activo
+        startUpdateTask();
+        
+        return true;
+    }
+    
+    /**
+     * Termina el control de torreta de un jugador
+     */
+    public static void stopControlling(Player player) {
+        UUID playerId = player.getUniqueId();
+        UUID turretId = ACTIVE_CONTROLLERS.get(playerId);
+        
+        if (turretId != null) {
+            // Remover del control
+            ACTIVE_CONTROLLERS.remove(playerId);
+            CONTROLLED_TURRETS.remove(turretId);
+            
+            // Liberar al jugador
+            player.removePotionEffect(PotionEffectType.SLOWNESS);
+            player.removePotionEffect(PotionEffectType.JUMP_BOOST);
+            
+            // Resetear la cabeza de la torreta
+            Turret turret = TurretManager.getTurret(turretId);
+            if (turret != null) {
+                ArmorStand stand = turret.getArmorStand();
+                if (stand != null) {
+                    stand.setHeadPose(new EulerAngle(0, 0, 0));
+                }
+            }
+            
+            player.sendMessage("§cHas dejado de controlar la torreta.");
+            
+            // Detener el task si no hay más controladores
+            if (ACTIVE_CONTROLLERS.isEmpty()) {
+                stopUpdateTask();
+            }
+        }
+    }
+    
+    /**
+     * Verifica si un jugador está controlando una torreta
+     */
+    public static boolean isControlling(Player player) {
+        return ACTIVE_CONTROLLERS.containsKey(player.getUniqueId());
+    }
+    
+    /**
+     * Obtiene la torreta que está controlando un jugador
+     */
+    public static Turret getControlledTurret(Player player) {
+        UUID turretId = ACTIVE_CONTROLLERS.get(player.getUniqueId());
+        if (turretId != null) {
+            return TurretManager.getTurret(turretId);
+        }
+        return null;
+    }
+    
+    /**
+     * Inicia el task de actualización de rotaciones
+     */
+    private static void startUpdateTask() {
+        if (updateTask != null && !updateTask.isCancelled()) {
+            return;
+        }
+        
+        updateTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Map.Entry<UUID, UUID> entry : ACTIVE_CONTROLLERS.entrySet()) {
+                    Player player = Bukkit.getPlayer(entry.getKey());
+                    Turret turret = TurretManager.getTurret(entry.getValue());
+                    
+                    if (player == null || !player.isOnline() || turret == null) {
+                        // Limpiar entradas inválidas
+                        ACTIVE_CONTROLLERS.remove(entry.getKey());
+                        CONTROLLED_TURRETS.remove(entry.getValue());
+                        continue;
+                    }
+                    
+                    updateTurretRotation(player, turret);
+                }
+                
+                // Si no hay más controladores, detener el task
+                if (ACTIVE_CONTROLLERS.isEmpty()) {
+                    cancel();
+                }
+            }
+        };
+        
+        updateTask.runTaskTimer(getPlugin(), 0L, 1L); // Actualizar cada tick
+    }
+    
+    /**
+     * Detiene el task de actualización
+     */
+    private static void stopUpdateTask() {
+        if (updateTask != null && !updateTask.isCancelled()) {
+            updateTask.cancel();
+        }
+    }
+    
+    /**
+     * Actualiza la rotación de la cabeza de la torreta basada en la vista del jugador
+     */
+    private static void updateTurretRotation(Player player, Turret turret) {
+        ArmorStand stand = turret.getArmorStand();
+        if (stand == null) return;
+        
+        Location playerLoc = player.getEyeLocation();
+        Location turretLoc = stand.getEyeLocation();
+        
+        // Calcular la diferencia de yaw (rotación horizontal)
+        float playerYaw = playerLoc.getYaw();
+        float turretYaw = turretLoc.getYaw();
+        float yawDiff = normalizeAngle(playerYaw - turretYaw);
+        
+        // Limitar el yaw dentro del rango permitido
+        yawDiff = Math.max((float)-MAX_YAW_OFFSET, Math.min((float)MAX_YAW_OFFSET, yawDiff));
+        
+        // Calcular el pitch (rotación vertical)
+        float playerPitch = playerLoc.getPitch();
+        
+        // Limitar el pitch dentro del rango permitido
+        float limitedPitch = (float) Math.max(MAX_PITCH_UP, Math.min(MAX_PITCH_DOWN, playerPitch));
+        
+        // Convertir a radianes para EulerAngle
+        double yawRadians = Math.toRadians(yawDiff);
+        double pitchRadians = Math.toRadians(limitedPitch);
+        
+        // Aplicar la rotación a la cabeza del ArmorStand
+        stand.setHeadPose(new EulerAngle(pitchRadians, yawRadians, 0));
+    }
+    
+    /**
+     * Normaliza un ángulo para que esté entre -180 y 180
+     */
+    private static float normalizeAngle(float angle) {
+        while (angle > 180f) angle -= 360f;
+        while (angle < -180f) angle += 360f;
+        return angle;
+    }
+    
+    /**
+     * Maneja el disparo de una torreta controlada
+     */
+    public static void fireTurret(Player player) {
+        Turret turret = getControlledTurret(player);
+        if (turret != null && turret.isActive()) {
+            ArmorStand stand = turret.getArmorStand();
+            if (stand != null) {
+                turret.fire(player, stand);
+            }
+        }
+    }
+    
+    /**
+     * Limpia todos los controladores (usar al desactivar el plugin)
+     */
+    public static void cleanup() {
+        for (UUID playerId : ACTIVE_CONTROLLERS.keySet()) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null) {
+                stopControlling(player);
+            }
+        }
+        ACTIVE_CONTROLLERS.clear();
+        CONTROLLED_TURRETS.clear();
+        stopUpdateTask();
+    }
+    
+    /**
+     * Obtiene la instancia del plugin (necesario para el scheduler)
+     */
+    private static org.bukkit.plugin.Plugin getPlugin() {
+        // Asumiendo que tu plugin se llama algo así, ajusta según tu clase principal
+        return Bukkit.getPluginManager().getPlugin("MobsAndDefenses");
+    }
+}
+

--- a/src/main/java/com/demo/defenses/manager/TurretManager.java
+++ b/src/main/java/com/demo/defenses/manager/TurretManager.java
@@ -66,4 +66,17 @@ public class TurretManager {
         register(turret);
         return stand;
     }
+
+    /**
+     * Destruye la torreta y la elimina del registro
+     */
+    public static void destroyTurret(UUID id) {
+        Turret turret = TURRETS.remove(id);
+        if (turret != null) {
+            ArmorStand stand = turret.getArmorStand();
+            if (stand != null) {
+                stand.remove();
+            }
+        }
+    }
 }

--- a/src/main/java/com/demo/defenses/model/Turret.java
+++ b/src/main/java/com/demo/defenses/model/Turret.java
@@ -45,12 +45,48 @@ public class Turret {
     }
 
     public void fire(Player controller, ArmorStand stand) {
-        if (!isReady()) return;
-        Location eye = stand.getEyeLocation();
-        Vector dir = controller.getEyeLocation().getDirection();
-        Arrow arrow = stand.getWorld().spawnArrow(eye, dir, 1f, 0f);
+        if (!isReady()) {
+            controller.sendMessage("§6Torreta recargando... (" +
+                ((type.getReloadTime() - (System.currentTimeMillis() - lastShot)) / 1000.0) + "s)");
+            return;
+        }
+
+        // Obtener la posición de disparo desde la cabeza del ArmorStand
+        Location shootLocation = stand.getEyeLocation();
+
+        // Usar la dirección exacta de donde está mirando el jugador
+        Vector direction = controller.getEyeLocation().getDirection().normalize();
+
+        // Crear la flecha
+        Arrow arrow = stand.getWorld().spawnArrow(shootLocation, direction, 2.0f, 0.1f);
         arrow.setShooter(stand);
+
+        // Configurar propiedades de la flecha según el tipo de torreta
+        switch (type) {
+            case DISPENSER:
+                arrow.setDamage(4.0);
+                break;
+            case DROPPER:
+                arrow.setDamage(2.0);
+                break;
+            case OBSERVER:
+                arrow.setDamage(6.0);
+                arrow.setFireTicks(100);
+                break;
+            case CRAFTER:
+                arrow.setDamage(8.0);
+                arrow.setCritical(true);
+                break;
+        }
+
+        // Actualizar tiempo del último disparo
         lastShot = System.currentTimeMillis();
+
+        // Mensaje al jugador
+        controller.sendMessage("§e¡Disparo! Tipo: " + type.name());
+
+        // Efecto de sonido
+        stand.getWorld().playSound(shootLocation, org.bukkit.Sound.ENTITY_ARROW_SHOOT, 1.0f, 1.0f);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `TurretControlManager` with yaw/pitch limits and firing helpers
- update interact listener to control turrets and prevent movement
- extend turret model with directional firing behaviour
- add destroy routine in `TurretManager`
- clean up turret controls on plugin disable

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d98d492348330b4a51cd33a6b0a67