### PR TITLE
Implement custom turret inventory holder

### DIFF
--- a/src/main/java/com/demo/defenses/listener/TurretInventoryListener.java
+++ b/src/main/java/com/demo/defenses/listener/TurretInventoryListener.java
@@ -1,12 +1,12 @@
 package com.demo.defenses.listener;
 
-import org.bukkit.entity.ArmorStand;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 
 import com.demo.defenses.manager.TurretManager;
 import com.demo.defenses.model.Turret;
+import com.demo.defenses.model.TurretInventoryHolder;
 
 
 /**
@@ -16,8 +16,8 @@ public class TurretInventoryListener implements Listener {
 
     @EventHandler
     public void onOpen(InventoryOpenEvent e) {
-        if (!(e.getInventory().getHolder() instanceof ArmorStand stand)) return;
-        Turret turret = TurretManager.getTurret(stand.getUniqueId());
+        if (!(e.getInventory().getHolder() instanceof TurretInventoryHolder holder)) return;
+        Turret turret = TurretManager.getTurret(holder.getStandId());
         if (turret == null) return;
         // Ya no llenamos automáticamente el inventario
         // El jugador debe agregar manualmente la munición apropiada

--- a/src/main/java/com/demo/defenses/manager/TurretManager.java
+++ b/src/main/java/com/demo/defenses/manager/TurretManager.java
@@ -64,7 +64,13 @@ public class TurretManager {
             as.setHealth(20.0); // 10 corazones de vida
         });
 
-        Inventory inv = Bukkit.createInventory(stand, 9, "Turret");
+        // Use a custom inventory holder so we can associate the inventory
+        // with an armor stand that normally does not implement InventoryHolder
+        com.demo.defenses.model.TurretInventoryHolder holder =
+                new com.demo.defenses.model.TurretInventoryHolder(stand.getUniqueId());
+        Inventory inv = Bukkit.createInventory(holder, 9, "Turret");
+        holder.setInventory(inv);
+
         Turret turret = new Turret(stand.getUniqueId(), type, inv);
         register(turret);
         return stand;

--- a/src/main/java/com/demo/defenses/model/TurretInventoryHolder.java
+++ b/src/main/java/com/demo/defenses/model/TurretInventoryHolder.java
@@ -1,0 +1,31 @@
+package com.demo.defenses.model;
+
+import java.util.UUID;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * Custom InventoryHolder to associate an inventory with a turret armor stand.
+ */
+public class TurretInventoryHolder implements InventoryHolder {
+    private final UUID standId;
+    private Inventory inventory;
+
+    public TurretInventoryHolder(UUID standId) {
+        this.standId = standId;
+    }
+
+    public UUID getStandId() {
+        return standId;
+    }
+
+    public void setInventory(Inventory inventory) {
+        this.inventory = inventory;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+}


### PR DESCRIPTION
## Summary
- create `TurretInventoryHolder` to attach inventories to armor stands
- use the new holder when spawning turrets
- update inventory listener to handle `TurretInventoryHolder`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dadaec7ec8330ac74e4c07f26fb5f