### PR TITLE
Fix plugin instance handling

### DIFF
--- a/src/main/java/com/demo/MobsAndDefenses.java
+++ b/src/main/java/com/demo/MobsAndDefenses.java
@@ -6,9 +6,22 @@ import com.demo.managers.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class MobsAndDefenses extends JavaPlugin {
+    /**
+     * Singleton instance used by managers that require a plugin reference.
+     * This avoids passing {@code null} when scheduling tasks.
+     */
+    private static MobsAndDefenses instance;
+
+    /** Returns the running plugin instance. */
+    public static MobsAndDefenses getInstance() {
+        return instance;
+    }
 
     @Override
     public void onEnable() {
+        // Save the instance for global access
+        instance = this;
+
         // Initialize managers
         PluginManager.getInstance().initialize(this);
         ConfigManager configManager = PluginManager.getInstance().getConfigManager();

--- a/src/main/java/com/demo/managers/PluginManager.java
+++ b/src/main/java/com/demo/managers/PluginManager.java
@@ -13,12 +13,23 @@ public class PluginManager {
         return instance;
     }
 
+    /**
+     * Initializes the manager with the running plugin instance.
+     * This should only be called once from the plugin's {@code onEnable}.
+     */
     public void initialize(JavaPlugin plugin) {
-        this.plugin = plugin;
-        this.configManager = new ConfigManager(plugin);
+        if (this.plugin != null) {
+            return; // already initialised
+        }
+        this.plugin = java.util.Objects.requireNonNull(plugin, "plugin");
+        this.configManager = new ConfigManager(this.plugin);
     }
 
+    /** Returns the stored plugin instance. */
     public JavaPlugin getPlugin() {
+        if (plugin == null) {
+            throw new IllegalStateException("PluginManager not initialized");
+        }
         return plugin;
     }
 


### PR DESCRIPTION
## Summary
- keep a static reference of the plugin instance for other managers
- guard against null plugin use in `PluginManager`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc688ad948330bdb4038b02a2096f